### PR TITLE
Avoid duplicate permission requests

### DIFF
--- a/lib/cogs/commands/meta/__init__.py
+++ b/lib/cogs/commands/meta/__init__.py
@@ -1,6 +1,7 @@
 from lib.wegbot import Wegbot
 from .meta_admin_channel import MetaAdminChannelCog
 from .meta_key_value import MetaKeyValueCog
+from .meta_permission_request import MetaPermissionRequestCog
 from .meta_roles import MetaRolesCog
 
 
@@ -8,3 +9,4 @@ def setup(bot: Wegbot):
     bot.add_cog(MetaRolesCog(bot))
     bot.add_cog(MetaKeyValueCog(bot))
     bot.add_cog(MetaAdminChannelCog(bot))
+    bot.add_cog(MetaPermissionRequestCog(bot))

--- a/lib/cogs/commands/meta/meta_permission_request.py
+++ b/lib/cogs/commands/meta/meta_permission_request.py
@@ -6,6 +6,7 @@ class MetaPermissionRequestCog(WegbotCog, name="MetaPermissionRequest", command_
 
     @commands.is_owner()
     @commands.guild_only()
+    @WegbotCog.has_table("permission_requests")
     @commands.group("pr", aliases=["fake-request"])
     async def cmd(self, ctx: commands.Context, permission_name: str):
         await self.bot.request_permission(ctx.channel, permission_name)

--- a/lib/cogs/commands/meta/meta_permission_request.py
+++ b/lib/cogs/commands/meta/meta_permission_request.py
@@ -1,0 +1,11 @@
+from discord.ext import commands
+from lib.cogs.base import WegbotCog
+
+
+class MetaPermissionRequestCog(WegbotCog, name="MetaPermissionRequest", command_attrs=dict(hidden=True)):
+
+    @commands.is_owner()
+    @commands.guild_only()
+    @commands.group("pr", aliases=["fake-request"])
+    async def cmd(self, ctx: commands.Context, permission_name: str):
+        await self.bot.request_permission(ctx.channel, permission_name)

--- a/lib/cogs/extensions/pinner/pinner.py
+++ b/lib/cogs/extensions/pinner/pinner.py
@@ -8,6 +8,7 @@ class PinnerCog(WegbotCog, name="Pinner"):
 
     default_threshold = 3
 
+    @WegbotCog.has_table("permission_requests")
     @WegbotCog.listener()
     async def on_reaction_add(self, reaction: discord.Reaction, _user):
         """ Pin a message if it gets enough pin reacts """
@@ -26,38 +27,10 @@ class PinnerCog(WegbotCog, name="Pinner"):
 
             try:
                 await reaction.message.pin()
-            except discord.Forbidden:
+            except discord.Forbidden as e:
                 # unable to pin - need Manage Messages permission in this channel
                 print(f"pinner: {guild.name} :: lack manage_messages permission in #{reaction.message.channel.name}")
-                await self.notify_lacking_permissions(reaction.message.channel)
+                print(f"pinner: DEBUG - {e.response.status} {e.response.reason} [{e.code}] - {e.text}")
+                await self.bot.request_permission(reaction.message.channel, "manage_messages")
 
             # TODO: build embed and find somewhere to dump it
-
-    async def notify_lacking_permissions(self, channel: discord.TextChannel):
-        """ Notify the admins of this server that the bot does not have proper permissions to pin """
-
-        # get admin channel
-        guild: discord.Guild = channel.guild
-        admin_channel: discord.TextChannel = self.db.admin_channel.get(guild)
-
-        if admin_channel is None:
-            # no admin channel, cannot notify
-
-            print(f"pinner: {guild.name} :: no admin channel linked; unable to bug guild admins for permission")
-            return
-
-        # explicitly mention bot owner (me) if a member of the server and can see admin channel,
-        # else default to guild owner
-        target_member: discord.Member = discord.utils.get(guild.members, id=self.bot.owner_id)
-        target_member = (
-            target_member if target_member is not None and admin_channel.permissions_for(target_member).read_messages
-            else guild.owner
-        )
-
-        # admin channel exists, notify
-        await admin_channel.send(
-            f"{target_member.mention}, i need the 'Manage Messages' permission to pin a message in " +
-            f"{channel.mention} and i'm bugging you for it now. if you don't want to give " +
-            "me this permission that's okay; just revoke my 'Read Messages' permission to disable pinning in " +
-            f"{channel.mention}."
-        )

--- a/lib/database/database.py
+++ b/lib/database/database.py
@@ -1,8 +1,8 @@
 import sqlite3
 from pathlib import Path
 
+from .handlers import RolesHandler, KeyValueHandler, AdminChannelHandler, PermissionRequestsHandler
 from .paths import get_data_dir
-from .handlers import RolesHandler, KeyValueHandler, AdminChannelHandler
 
 
 class WegbotDatabase:
@@ -16,6 +16,7 @@ class WegbotDatabase:
         self.roles = RolesHandler(self.file)
         self.key_value = KeyValueHandler(self.file)
         self.admin_channel = AdminChannelHandler(self.file)
+        self.permission_requests = PermissionRequestsHandler(self.file)
 
     def initialize(self):
         if self.__initialized:
@@ -24,6 +25,7 @@ class WegbotDatabase:
         self.roles.initialize()
         self.key_value.initialize()
         self.admin_channel.initialize()
+        self.permission_requests.initialize()
 
         self.__initialized = True
 

--- a/lib/database/handlers/__init__.py
+++ b/lib/database/handlers/__init__.py
@@ -1,3 +1,4 @@
-from .roles import RolesHandler
-from .key_value import KeyValueHandler
 from .admin_channel import AdminChannelHandler
+from .key_value import KeyValueHandler
+from .permission_requests import PermissionRequestsHandler
+from .roles import RolesHandler

--- a/lib/database/handlers/key_value.py
+++ b/lib/database/handlers/key_value.py
@@ -10,7 +10,7 @@ class KeyValueHandler(DatabaseHandler):
         super().__init__(db_file, "key_value",
                          "key TEXT NOT NULL, value TEXT, guild_id TEXT NOT NULL, UNIQUE(key, guild_id)")
 
-    def get(self, key: str, guild: discord.Guild, default=None):
+    def get(self, key: str, guild: discord.Guild, default=None, transform=lambda v: v):
         cur = self.db.cursor()
         cur.execute("SELECT value FROM key_value WHERE key = ? AND guild_id = ?", (key, str(guild.id)))
         fetched: list = cur.fetchone()
@@ -19,7 +19,7 @@ class KeyValueHandler(DatabaseHandler):
             return default
         value = fetched[0]
         print(f"database: {guild.name} :: {key} = {value}")
-        return value
+        return transform(value)
 
     def has(self, key: str, guild: discord.Guild):
         return self.get(key, guild, default=None) is not None

--- a/lib/database/handlers/permission_requests.py
+++ b/lib/database/handlers/permission_requests.py
@@ -1,0 +1,46 @@
+from lib.database.handlers.base import DatabaseHandler
+
+import discord
+from datetime import datetime
+from pathlib import Path
+
+
+class PermissionRequestsHandler(DatabaseHandler):
+    """ Keeps track of permission requests, to ensure we do not send too many duplicates. """
+
+    tablename: str = "permission_requests"
+    schema: str = "channel_id TEXT NOT NULL, permission_name TEXT NOT NULL, timestamp TEXT NOT NULL, " + \
+                  "UNIQUE(channel_id, permission_name)"
+
+    def __init__(self, db_file: Path):
+        super().__init__(db_file, PermissionRequestsHandler.tablename, PermissionRequestsHandler.schema)
+
+    def get(self, channel: discord.TextChannel, perm: str):
+        """ Retrieves a :class:`datetime.datetime` representing the last time this permission
+        was requested for this channel """
+        print(f"database: {channel.guild.name} :: checking last permission request for '{perm}' in '#{channel.name}'")
+        cur = self.db.cursor()
+        cur.execute("SELECT timestamp FROM permission_requests WHERE channel_id = ? AND permission_name = ?",
+                    (str(channel.id), perm))
+        fetched: list = cur.fetchone()
+        if fetched is None or len(fetched) == 0:
+            print(f"database: {channel.guild.name} :: permission '{perm}' not yet requested for '#{channel.name}'")
+            return None
+        value = fetched[0]
+        print(f"database: {channel.guild.name} :: '{perm}' in '#{channel.name}' last requested: {value}")
+        return datetime.utcfromtimestamp(float(value))
+
+    def has(self, channel: discord.TextChannel, perm: str):
+        return self.get(channel, perm) is not None
+
+    def set(self, channel: discord.TextChannel, perm: str, when: datetime = datetime.utcnow()):
+        print(f"database: {channel.guild.name} :: logging permission request for '{perm}' in '#{channel.name}'")
+        sql_str = "INSERT OR REPLACE INTO permission_requests (channel_id, permission_name, timestamp) VALUES (?,?,?)"
+        self.db.execute(sql_str, (str(channel.id), perm, str(when.timestamp())))
+        self.db.commit()
+
+    def delete(self, channel: discord.TextChannel, perm: str):
+        print(f"database: {channel.guild.name} :: deleting last permission request for '{perm}' in '#{channel.name}'")
+        sql_str = "DELETE FROM permission_requests WHERE channel_id = ? AND permission_name = ?"
+        self.db.execute(sql_str, (str(channel.id), perm))
+        self.db.commit()

--- a/lib/wegbot/wegbot.py
+++ b/lib/wegbot/wegbot.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 import discord
 from discord.ext import commands
 
@@ -11,6 +13,8 @@ class Wegbot(commands.Bot):
     version: str = "v3.0.2"
     default_activity: discord.Activity = discord.Game(name=f"wegbot {version} – ?help")
 
+    permission_request_interval: timedelta = timedelta(hours=12)
+
     def __init__(self, command_prefix="?"):
         super().__init__(command_prefix, description=Wegbot.description, activity=Wegbot.default_activity)
         self.db: WegbotDatabase = WegbotDatabase()
@@ -18,3 +22,53 @@ class Wegbot(commands.Bot):
     async def on_ready(self):
         print(f"logged in as {self.user}")
         self.db.initialize()
+
+    async def request_permission(self, channel: discord.TextChannel, permission_name: str):
+        """ Notify the admins of this server that the bot does not have proper permissions to pin """
+
+        # check to make sure server has allowed permission requests
+        can_bug: bool = self.db.key_value.get("request_permissions", channel.guild, default=False, transform=bool)
+        if not can_bug:
+            print(
+                f"wegbot: {channel.guild.name} :: unable to request '{permission_name}' permission in " +
+                f"'#{channel.name}' as the server has not allowed it"
+            )
+            return
+
+        # check last time permissions were requested, to avoid duplicates
+        last_request: datetime = self.db.permission_requests.get(channel, permission_name)
+        if last_request is not None:
+            time_since: timedelta = datetime.utcnow() - last_request
+            if time_since < Wegbot.permission_request_interval:
+                print(f"wegbot: {channel.guild.name} :: unable to request '{permission_name}' permission in " +
+                      f"'#{channel.name}' as it was recently requested")
+                return
+
+        # get admin channel
+        guild: discord.Guild = channel.guild
+        admin_channel: discord.TextChannel = self.db.admin_channel.get(guild)
+
+        if admin_channel is None:
+            # no admin channel, cannot notify
+            print(f"wegbot: {guild.name} :: no admin channel linked; unable to bug guild admins for permission")
+            return
+
+        await admin_channel.trigger_typing()
+
+        # explicitly mention bot owner (me) if a member of the server and can see admin channel,
+        # else default to guild owner
+        target_member: discord.Member = discord.utils.get(guild.members, id=self.owner_id)
+        target_member = (
+            target_member if target_member is not None and admin_channel.permissions_for(
+                target_member).read_messages
+            else guild.owner
+        )
+
+        # log this request
+        self.db.permission_requests.set(channel, permission_name)
+
+        # admin channel exists, notify
+        await admin_channel.send(
+            f"{target_member.mention}, i need the `{permission_name}` permission in {channel.mention} and i'm " +
+            "bugging you for it now."
+        )


### PR DESCRIPTION
Resolve #5 where the bot could potentially request permissions an indefinitely number of times as long as a message is pinned and unpinned. This thankfully only occurred once before the edge case was discovered.