### PR TITLE
Multiple roles cannot be added as requestable at once

### DIFF
--- a/lib/cogs/commands/meta/meta_roles.py
+++ b/lib/cogs/commands/meta/meta_roles.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import typing
 
 import discord
 from discord.ext import commands
@@ -37,17 +38,26 @@ class MetaRolesCog(WegbotCog, name="MetaRoles"):
 
     @WegbotCog.is_mod()
     @cmd.command("add", hidden=True)
-    async def add(self, ctx: commands.Context, *, role_name: str):
+    async def add(self, ctx: commands.Context, *role_names):
         """ Add a requestable role to the database """
-        role: discord.Role = discord.utils.get(ctx.guild.roles, name=role_name)
 
-        if role is None:
-            raise NoSuchRoleError(role_name)
+        if len(role_names) < 1:
+            await ctx.send(f"{ctx.author.mention}, you have to give me some roles to add...")
+            return
 
-        # TODO check that role is not a mod role (users should NOT be able to request mod roles)
+        new_requestable_roles: typing.List[discord.Role] = []
+        for role_name in role_names:
+            role: discord.Role = discord.utils.get(ctx.guild.roles, name=role_name)
 
-        self.db.roles.put(role)
-        await ctx.send(f"{ctx.author.mention}, `{role.name}` can now be requested here.")
+            if role is None:
+                raise NoSuchRoleError(role_name)
+
+            self.db.roles.put(role)
+            new_requestable_roles.append(role)
+
+        new_roles_msg: typing.List[str] = [f"`{role.name}`" for role in new_requestable_roles]
+        new_roles_msg: str = ', '.join(new_roles_msg)
+        await ctx.send(f"{ctx.author.mention}, the following roles can now be requested here: {new_roles_msg}")
 
     @WegbotCog.is_mod()
     @cmd.command("remove", hidden=True)

--- a/lib/cogs/commands/meta/meta_roles.py
+++ b/lib/cogs/commands/meta/meta_roles.py
@@ -22,8 +22,8 @@ class MetaRolesCog(WegbotCog, name="MetaRoles"):
     @cmd.command("list")
     async def list(self, ctx: commands.Context):
         """ List available roles """
-        roles = self.db.roles.get_all(ctx.guild)
-        role_names = [f"`{r.name}`" for r in roles if r is not None]
+        roles: typing.List[discord.Role] = self.db.roles.get_all(ctx.guild)
+        role_names: typing.List[str] = [f"`{r.name}`" for r in roles if r is not None] if roles is not None else []
 
         roles_summary: str = "\n".join(role_names) if len(role_names) > 0 else "**(none)**"
 
@@ -47,7 +47,7 @@ class MetaRolesCog(WegbotCog, name="MetaRoles"):
 
         new_requestable_roles: typing.List[discord.Role] = []
         for role_name in role_names:
-            role: discord.Role = discord.utils.get(ctx.guild.roles, name=role_name)
+            role: discord.Role = discord.utils.find(lambda r: r.name.upper() == role_name.upper(), ctx.guild.roles)
 
             if role is None:
                 raise NoSuchRoleError(role_name)
@@ -63,7 +63,7 @@ class MetaRolesCog(WegbotCog, name="MetaRoles"):
     @cmd.command("remove", hidden=True)
     async def remove(self, ctx: commands.Context, *, role_name: str):
         """ Remove a requestable role from the database """
-        role: discord.Role = discord.utils.get(ctx.guild.roles, name=role_name)
+        role: discord.Role = discord.utils.find(lambda r: r.name.upper() == role_name.upper(), ctx.guild.roles)
 
         if role is None:
             raise NoSuchRoleError(role_name)


### PR DESCRIPTION
Resolve #8 - allow adding multiple requestable roles at once.

Note: this solution breaks with roles with spaces in them. Currently none exist and none are planned to exist, so this isn't an issue. This may break in the future.